### PR TITLE
Hide dangerous buttons on Queues and Busy pages

### DIFF
--- a/lib/sidekiq/version.rb
+++ b/lib/sidekiq/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Sidekiq
-  VERSION = "5.0.3"
+  VERSION = "5.0.3.sd.1"
 end

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -1,3 +1,19 @@
+<script type="text/javascript">
+  function toggleQuietAndStopProcessActions() {
+    var checkbox = $('input[name="quietAndStopProcessCheckbox"]');
+    var quietButtons = $('button[name="quiet"]')
+    var stopButtons = $('button[name="stop"]')
+
+    if (checkbox.is(":checked")) {
+      quietButtons.show();
+      stopButtons.show();
+    } else {
+      quietButtons.hide();
+      stopButtons.hide();
+    }
+  }
+</script>
+
 <div class="row header">
   <div class="col-sm-8 pull-left flip">
     <h3><%= t('Processes') %></h3>
@@ -6,8 +22,8 @@
     <form method="POST" class="warning-messages">
       <%= csrf_tag %>
       <div class="btn-group pull-right flip">
-        <button class="btn btn-warn" type="submit" name="quiet" value="1" data-confirm="<%= t('AreYouSure') %>"><%= t('QuietAll') %></button>
-        <button class="btn btn-danger" type="submit" name="stop" value="1" data-confirm="<%= t('AreYouSure') %>"><%= t('StopAll') %></button>
+        <button style="display: none;" class="btn btn-warn" type="submit" name="quiet" value="1" data-confirm="<%= t('AreYouSure') %>"><%= t('QuietAll') %></button>
+        <button style="display: none;" class="btn btn-danger" type="submit" name="stop" value="1" data-confirm="<%= t('AreYouSure') %>"><%= t('StopAll') %></button>
       </div>
     </form>
   </div>
@@ -20,7 +36,10 @@
       <th><%= t('Started') %></th>
       <th><%= t('Threads') %></th>
       <th><%= t('Busy') %></th>
-      <th>&nbsp;</th>
+      <th>
+        <input type="checkbox" name="quietAndStopProcessCheckbox" value="yes" onclick="toggleQuietAndStopProcessActions();">
+        <%= t('Actions') %>
+      </th>
     </thead>
     <% lead = processes.leader %>
     <% processes.each do |process| %>
@@ -50,9 +69,9 @@
               <%= csrf_tag %>
               <input type="hidden" name="identity" value="<%= process['identity'] %>"/>
               <% unless process.stopping? %>
-                <button class="btn btn-warn" type="submit" name="quiet" value="1"><%= t('Quiet') %></button>
+                <button style="display: none;" class="btn btn-warn" type="submit" name="quiet" value="1"><%= t('Quiet') %></button>
               <% end %>
-              <button class="btn btn-danger" type="submit" name="stop" value="1"><%= t('Stop') %></button>
+              <button style="display: none;" class="btn btn-danger" type="submit" name="stop" value="1"><%= t('Stop') %></button>
             </form>
           </div>
         </td>
@@ -71,8 +90,6 @@
   <table class="workers table table-hover table-bordered table-striped table-white">
     <thead>
       <th><%= t('Process') %></th>
-      <th><%= t('TID') %></th>
-      <th><%= t('JID') %></th>
       <th><%= t('Queue') %></th>
       <th><%= t('Job') %></th>
       <th><%= t('Arguments') %></th>
@@ -81,15 +98,13 @@
     <% workers.each do |process, thread, msg| %>
       <% job = Sidekiq::Job.new(msg['payload']) %>
       <tr>
-        <td><%= process %></td>
-        <td><%= thread %></td>
-        <td><%= job.jid %></td>
+        <td><%= process.split(':').first %></td>
         <td>
           <a href="<%= root_path %>queues/<%= msg['queue'] %>"><%= msg['queue'] %></a>
         </td>
         <td><%= job.display_class %></td>
         <td>
-          <div class="args"><%= display_args(job.display_args) %></div>
+          <div class="args"><%= job.display_args %></div>
         </td>
         <td><%= relative_time(Time.at(msg['run_at'])) %></td>
       </tr>

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -1,3 +1,16 @@
+<script type="text/javascript">
+  function toggleDeleteQueueAction() {
+    var checkbox = $('input[name="deleteQueueCheckbox"]');
+    var buttons  = $('input[name="delete"]')
+
+    if (checkbox.is(":checked")) {
+      buttons.show();
+    } else {
+      buttons.hide();
+    }
+  }
+</script>
+
 <h3><%= t('Queues') %></h3>
 
 <div class="table_container">
@@ -5,7 +18,10 @@
     <thead>
       <th><%= t('Queue') %></th>
       <th><%= t('Size') %></th>
-      <th><%= t('Actions') %></th>
+      <th>
+        <input type="checkbox" name="deleteQueueCheckbox" value="yes" onclick="toggleDeleteQueueAction();">
+        <%= t('Actions') %>
+      </th>
     </thead>
     <% @queues.each do |queue| %>
       <tr>
@@ -19,10 +35,12 @@
         <td class="delete-confirm">
           <form action="<%=root_path %>queues/<%= CGI.escape(queue.name) %>" method="post">
             <%= csrf_tag %>
-            <input class="btn btn-danger btn-xs" type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteQueue', :queue => h(queue.name)) %>" />
+            <input style="display: none;" class="btn btn-danger btn-xs" type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteQueue', :queue => h(queue.name)) %>" />
           </form>
         </td>
       </tr>
     <% end %>
   </table>
 </div>
+
+


### PR DESCRIPTION
1. Hide by default 'Delete' buttons on Queues page;
2. Hide by default 'Quiet All', 'Stop All', 'Quiet', 'Stop' buttons on 'Busy' page;
3. Trim process name on Busy page;
4. Remove TID, JID columns from Busy page;
5. Do not truncate Job Arguments on Busy page.